### PR TITLE
Remove extra "s" in page titles

### DIFF
--- a/src/Html.scala
+++ b/src/Html.scala
@@ -53,7 +53,7 @@ object Html:
   def talksOverview(talks: Talks) =
     htmlWrapper(
       headFrag(
-        pageTitle = s"chris-kipp.io - s${talks.title}",
+        pageTitle = s"chris-kipp.io - ${talks.title}",
         description = talks.description
       ),
       body(

--- a/src/Html.scala
+++ b/src/Html.scala
@@ -113,7 +113,7 @@ object Html:
   def aboutPage() =
     htmlWrapper(
       headFrag(
-        pageTitle = "about - chris-kipp.io",
+        pageTitle = "chris-kipp.io - about",
         description =
           "A litte bit about me, Chris Kipp, the author of this blog."
       ),


### PR DESCRIPTION
Seems like a regression from [last week](https://github.com/ckipp01/chris-kipp.io/pull/25/commits/0152381a53825d17adf0cb8ceb1d392ddc98c1b1#diff-c69ae6d61f4a242a4509f269680a1b9a0e1692c6d6b71be83e6a7da20748f628L69-L70).

I found it by googling for the talks:

<img width="430" alt="image" src="https://user-images.githubusercontent.com/894884/216799125-3b1ada78-41f3-4acb-94f8-496293d0906a.png">

and it shows up in the browser:

<img width="248" alt="image" src="https://user-images.githubusercontent.com/894884/216799129-863b07d0-8222-4478-b9b5-dcfd5ea0a486.png">

so: fixing. Tested locally:

<img width="231" alt="image" src="https://user-images.githubusercontent.com/894884/216799364-ef541220-3180-444c-82fc-2f549c1d4eb0.png">

(also, why tf does Vercel require an account for running stuff locally???)

